### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -19,7 +19,7 @@ decode	KEYWORD2
 enableIRIn	KEYWORD2
 resume	KEYWORD2
 enableIROut	KEYWORD2
-send KEYWORD2
+send	KEYWORD2
 
 #
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords